### PR TITLE
SWEP breaking fix.

### DIFF
--- a/gamemodes/nzombies/entities/entities/random_box_windup/shared.lua
+++ b/gamemodes/nzombies/entities/entities/random_box_windup/shared.lua
@@ -62,6 +62,7 @@ function ENT:Use( activator, caller )
 	if !self:GetWinding() and self:GetWepClass() != "nz_box_teddy" then
 		if activator == self.Buyer then
 			local class = self:GetWepClass()
+			activator.LastUsedSWEP = activator:GetActiveWeapon()
 			activator:Give(class)
 			nz.Weps.Functions.GiveMaxAmmoWep(activator, class)
 			self.Box:Close()

--- a/gamemodes/nzombies/entities/entities/wall_buys/shared.lua
+++ b/gamemodes/nzombies/entities/entities/wall_buys/shared.lua
@@ -204,6 +204,7 @@ if SERVER then
 		if !activator:HasWeapon( self.WeaponGive ) then
 			if activator:CanAfford(price) then
 				activator:TakePoints(price)
+				activator.LastUsedSWEP = activator:GetActiveWeapon()
 				activator:Give(self.WeaponGive)
 				nz.Weps.Functions.GiveMaxAmmoWep(activator, self.WeaponGive)
 				self:SetBought(true)

--- a/gamemodes/nzombies/gamemode/weapons/sv_weps.lua
+++ b/gamemodes/nzombies/gamemode/weapons/sv_weps.lua
@@ -354,28 +354,19 @@ end)
 
 --hook.Add("OnEntityCreated", "nz.Weps.OnEntityCreated", nz.Weps.Functions.OnWepCreated)
 function GetPriorityWeaponSlot(ply)
-	if ply:HasPerk("mulekick") then
-		for i = 1, 3 do
-			local exists = false
-			for k,v in pairs(ply:GetWeapons()) do
-				if !exists and v:GetNWInt("SwitchSlot") == i then
-					exists = true
-				end
+	local lastused = ply.LastUsedSWEP or ply:GetActiveWeapon()
+	local ie = 2
+	if ply:HasPerk("mulekick") then ie = 3 end
+	for i = 1, ie do
+		local exists = false
+		for k,v in pairs(ply:GetWeapons()) do
+			if !exists and v:GetNWInt("SwitchSlot") == i then
+				exists = true
 			end
-			if !exists then return i end
 		end
-	else
-		for i = 1, 2 do
-			local exists = false
-			for k,v in pairs(ply:GetWeapons()) do
-				if !exists and v:GetNWInt("SwitchSlot") == i then
-					exists = true
-				end
-			end
-			if !exists then return i end
-		end
+		if !exists then return i end
 	end
-	return ply:GetActiveWeapon():GetNWInt("SwitchSlot", 1), true
+	return lastused:GetNWInt("SwitchSlot") or 1, true, lastused:GetClass()
 end
 
 local function OnWeaponAdded( weapon )
@@ -410,8 +401,8 @@ local function OnWeaponAdded( weapon )
 					end
 				end]]
 				
-				local slot, exists = GetPriorityWeaponSlot(ply)
-				if exists then ply:StripWeapon( ply:GetActiveWeapon():GetClass() ) end
+				local slot, exists, rmSWEP = GetPriorityWeaponSlot(ply)
+				if exists then ply:StripWeapon(rmSWEP) end
 				weapon:SetNWInt( "SwitchSlot", slot )
 				
 				weapon.Weight = 10000


### PR DESCRIPTION
as outlined in Issue #193.
First of all, i've changed the StripWeapon, so it won't be removing the
fresh bought weapon. Afterwards, this run into some problems with
GetNWInt, which used the new weapon instead of the old weapon.
This was fixed by adding an new variable attached to the plymeta, in
which the old weapon is stored as soon an buy is happening. On L357 of
sv_weps is also an failsafe, incase the function get called without
using one of the other methods, to still function properly.
