### PR TITLE
Ignore .tif and .tiff within addon.json

### DIFF
--- a/addon.json
+++ b/addon.json
@@ -7,5 +7,7 @@
 		"*.psd",
 		"*.vcproj",
 		"*.svn*"
+		"*.tif"
+		"*.tiff"
 	]
 }


### PR DESCRIPTION
This actually happened a while ago, just now getting to it.
Because I used a tiff file for a config icon, but it covered the entire screen, effectively breaking the config loader. This happens no matter the PPI (Pixels per Inch), and I use a 72x72 image.
