### PR TITLE
Fixed ERROR Spam When a Panzer is Defeated

### DIFF
--- a/gamemodes/nzombies/entities/entities/nz_zombie_boss_panzer.lua
+++ b/gamemodes/nzombies/entities/entities/nz_zombie_boss_panzer.lua
@@ -500,7 +500,7 @@ end
 function ENT:OnRemove()
 	if IsValid(self.ClawHook) then self.ClawHook:Remove() end
 	if IsValid(self.GrabbedPlayer) then self.GrabbedPlayer:SetMoveType(MOVETYPE_WALK) end
-	if self.FireEmitter then self.FireEmitter:Finish() end
+	if IsValid(self.FireEmitter) then self.FireEmitter:Finish() end
 end
 
 function ENT:StartFlames(time)


### PR DESCRIPTION
This works on my end when no addons and all addons are enabled (it should work regardless for you because I only added an `IsValid()` statement and not a hook).