### PR TITLE
Fix for "No special grenade ammo given when getting one from the Box"

### DIFF
--- a/gamemodes/nzombies/gamemode/weapons/sv_ammo.lua
+++ b/gamemodes/nzombies/gamemode/weapons/sv_ammo.lua
@@ -97,4 +97,15 @@ function meta:GiveMaxAmmo(papoverwrite)
 	ply:GiveAmmo(give_ammo, ammo_type)
 	ply:SetAmmo(max_ammo, ammo_type)
 	
+	if self:IsSpecial() then -- Give Max Ammo for special weapons when first getting them.
+		local wepdata = self.NZSpecialWeaponData
+		if !wepdata then return end
+		
+		local ammo = usesammo[self:GetSpecialCategory()] or wepdata.AmmoType
+		local maxammo = wepdata.MaxAmmo
+		
+		if ammo and maxammo then
+			self.Owner:SetAmmo(maxammo, GetNZAmmoID(ammo) or ammo) -- Special weapon ammo or just that ammo
+		end
+	end
 end


### PR DESCRIPTION
As the title suggests, players will get Special Grenade ammo (i.e.: Monkey Bombs) when getting a special grenade from the Mystery Box, unlike in the past few updates.