### PR TITLE
Fixed not being able to buy weapons that have overridden GetPrimaryAmmoType

### DIFF
--- a/gamemodes/nzombies/entities/entities/wall_buys/shared.lua
+++ b/gamemodes/nzombies/entities/entities/wall_buys/shared.lua
@@ -213,7 +213,7 @@ if SERVER then
 		end
 		if !wep then wep = weapons.Get(self.WeaponGive) end
 		if !wep then return end
-		local ammo_type = wep.GetPrimaryAmmoType and wep:GetPrimaryAmmoType() or wep.Primary.Ammo
+		local ammo_type = IsValid(wep) and wep:GetPrimaryAmmoType() or wep.Primary.Ammo
 
 		local ammo_price = math.ceil((price - (price % 10))/2)
 		local ammo_price_pap = 4500


### PR DESCRIPTION
This includes buying TFA weapons with having weapons from other bases as starting ones. (#418, #489, #509, #530, #543, #562, #568, #664)

https://yurie.thigh-high.club/kkssqnw5.mp4