### PR TITLE
Fixed oldsetwep

### DIFF
--- a/gamemodes/nzombies/gamemode/function_override/sh_meta.lua
+++ b/gamemodes/nzombies/gamemode/function_override/sh_meta.lua
@@ -164,7 +164,7 @@ if SERVER then
 		if IsValid(oldwep) and !oldwep:IsSpecial() then
 			self.NZPrevWep = oldwep
 		end
-		oldsetwep(self, wep)
+		oldsetwep(self, oldwep)
 	end
 	
 else


### PR DESCRIPTION
Fixed [ERROR] addons/nzombies-master-workshop/gamemodes/nzombies/gamemode/function_override/sh_meta.lua:167: bad argument #2 to 'oldsetwep' (Entity expected, got string)